### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/picatic/node-zoho.png?label=ready&title=Ready)](https://waffle.io/picatic/node-zoho)
 Zoho CRM rest api wrapper for node.js
 
 [![Build Status](https://travis-ci.org/picatic/node-zoho.png?branch=master)](https://travis-ci.org/picatic/node-zoho)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/picatic/node-zoho

This was requested by a real person (user interlock) on waffle.io, we're not trying to spam you.
