### PR TITLE
Fix response when inserting multiple records

### DIFF
--- a/lib/products/crm/crm-module.coffee
+++ b/lib/products/crm/crm-module.coffee
@@ -292,7 +292,8 @@ class CrmModule extends BaseModule
       if err
         if _.isFunction(cb) then cb(err,null)
       else
-        processed = @processRecord(response.data)
+        processed = for record in response.data
+          @processRecord(record)
         response.data = processed
         if _.isFunction(cb) then cb(null,response)
     )


### PR DESCRIPTION
`processRecord` method overwrites values in `processed` variable and thus only last record info is returned
