### PR TITLE
Adapt getRecordById to handle various object types; not just Events

### DIFF
--- a/lib/products/crm/crm-module.coffee
+++ b/lib/products/crm/crm-module.coffee
@@ -190,8 +190,8 @@ class CrmModule extends BaseModule
       if err
         if _.isFunction(cb) then cb(err,null)
       else
-        if response.data?.Events
-          row = _.first(response.data?.Events)
+        if response.data?[_this.name]
+          row = _.first(response.data?[_this.name])
           processed = @processRecord(_.first(row.row))
           response.data = processed
 


### PR DESCRIPTION
Original implementation of getRecordById would inspect the response body's JSON for an Events member; whereas in reality the available members will depend on which object type the caller is asking for.  E.g., Contacts, Leads, Accounts.