### PR TITLE
Fix broken upload file via body

### DIFF
--- a/lib/products/crm/crm-module.coffee
+++ b/lib/products/crm/crm-module.coffee
@@ -346,10 +346,10 @@ class CrmModule extends BaseModule
 
     form = r.form()
     form.append('id', id)
-    if _.isString(file)
-      form.append('attachmentUrl', file)
-    else
+    if descriptor
       form.append('content', file, descriptor)
+    else
+      form.append('attachmentUrl', file)
 
     return r
       

--- a/spec/unit/crm/crm-module-spec.coffee
+++ b/spec/unit/crm/crm-module-spec.coffee
@@ -343,7 +343,7 @@ describe 'crm module', ->
       fakeFile = 'http://fake.string/url.ext'
       spy = spyOn fakeForm, 'append'
 
-      crmModule.uploadFile '1234567890123456', fakeFile, fakeDescriptor
+      crmModule.uploadFile '1234567890123456', fakeFile
 
       expect(spy).toHaveBeenCalledWith 'id', '1234567890123456'
       expect(spy).toHaveBeenCalledWith 'attachmentUrl', fakeFile


### PR DESCRIPTION
When I started implement deleteFile I noticed that files attached via attachmentUrl only as direct links
![image](https://user-images.githubusercontent.com/13823215/36098287-1181c470-1007-11e8-9d22-bf93b37d275e.png)

So when I tried to upload it correctly I need to write code like this
```
const url = require("url"),
    path = require("path"),
    request = require("request");

const parsed = url.parse(remoteUrl),
    filename = path.basename(parsed.pathname);

request(remoteUrl, (error, res, body) => {
    if (error) return reject(error);

    const zoho = getZoho();
    zoho.execute('crm', module, method, id, body, {filename}, (err, result) => {
        let error;
        if (err !== null) {
            error = err;
        } else if (result.isError()) {
            error = result.message;
        }

        if (error) {
            reject(error);
        } else {
            resolve(result);
        }
    });
});
```

But in this case I noticed that file don't pass properly, cause body is a string.

So I change check condition in **uploadFile** and test for this function.

Then I successfully upload my file (first in the list)